### PR TITLE
Add provider stock management

### DIFF
--- a/src/assets/i18/en.js
+++ b/src/assets/i18/en.js
@@ -874,6 +874,11 @@ const en_us = {
       wechatId: 'Wechat ID',
       toExamine: 'To examine',
       finance: 'Finance',
+    },
+    inventory: {
+      totalStock: 'Total Stock',
+      locationStock: 'Stock By Location',
+      customerStock: 'Stock By Customer'
     }
   },
   navigate: {
@@ -918,6 +923,9 @@ const en_us = {
     batchWeighing: "Batch Weighing",
     printingTheWaybill: "Printing The Waybill",
     exceptionManagement: "Exception Management",
+    inventory: "Inventory",
+    inventoryStatistics: "Stock Statistics",
+    stockAdjustment: "Stock Adjustment",
     customerManagement: "Customer Management",
     customer: "Customer",
   },
@@ -979,6 +987,8 @@ const en_us = {
     takeDelivery: 'Take delivery',
     packingList: 'Packing list',
     operationType: 'Operation type',
+    increase: 'Increase',
+    decrease: 'Decrease',
     operationSuccessful: 'Operation successful',
     editSuccessful: 'Edit successful',
     operationFailed: 'Operation failed',

--- a/src/assets/i18/zh.js
+++ b/src/assets/i18/zh.js
@@ -877,6 +877,11 @@ const zh_cn = {
       wechatId: '微信ID',
       toExamine: '审核',
       finance: '财务',
+    },
+    inventory: {
+      totalStock: '总库存',
+      locationStock: '库位库存',
+      customerStock: '分仓库存'
     }
   },
   navigate: {
@@ -921,6 +926,9 @@ const zh_cn = {
     batchWeighing: "批量称重",
     printingTheWaybill: "打印运单",
     exceptionManagement: "异常管理",
+    inventory: "库内",
+    inventoryStatistics: "库存统计",
+    stockAdjustment: "库存更改",
     customerManagement: "客户管理",
     customer: "客户",
   },
@@ -983,6 +991,8 @@ const zh_cn = {
     takeDelivery: '收货',
     packingList: '箱单',
     operationType: '操作类型',
+    increase: '增加',
+    decrease: '减少',
     operationSuccessful: '操作成功',
     editSuccessful: '编辑成功',
     operationFailed: '操作失败',

--- a/src/components/base-layout/navigate.js
+++ b/src/components/base-layout/navigate.js
@@ -112,6 +112,30 @@ export const navigationDataProvider = [
         ]
       },
       {
+        title: 'navigate.inventory',
+        name: 'p-inventory',
+        path: '/p-inventory',
+        icon: 'el-icon-s-data',
+        role: ['Provider', 'Operator'],
+        notRouter: true,
+        children: [
+          {
+            title: 'navigate.inventoryStatistics',
+            name: 'p-stock-statistics',
+            path: '/p/stock-statistics',
+            component: 'stock-manage/p-stock-statistics.vue',
+            role: ['Provider', 'Operator']
+          },
+          {
+            title: 'navigate.stockAdjustment',
+            name: 'p-stock-adjust',
+            path: '/p/stock-adjust',
+            component: 'stock-manage/p-stock-adjust.vue',
+            role: ['Provider', 'Operator']
+          }
+        ]
+      },
+      {
         title: 'navigate.productManagement',
         name: 'p-product',
         path: '/p-product',
@@ -141,10 +165,11 @@ export const navigationDataProvider = [
             title: 'navigate.order',
             name: 'p-sub-order',
             path: '/p/order',
-            component: 'order-manage/p-order.vue',
-            role: ['Provider', 'Operator'],
-          }]
-      },]
+          component: 'order-manage/p-order.vue',
+          role: ['Provider', 'Operator'],
+        }]
+      },
+    ]
   },
   {
     title: 'navigate.storeManagement',

--- a/src/pages/stock-manage/p-stock-adjust.vue
+++ b/src/pages/stock-manage/p-stock-adjust.vue
@@ -1,0 +1,85 @@
+<template>
+  <div class="p-stock-adjust" v-loading="loading">
+    <PageHead :title="$t('navigate.stockAdjustment')"></PageHead>
+    <el-form :model="form" label-width="120px">
+      <el-form-item :label="$t('message.productManagement.productBarcode')">
+        <el-input v-model="form.barcode" />
+      </el-form-item>
+      <el-form-item :label="$t('message.storage.location')">
+        <el-input v-model="form.location" />
+      </el-form-item>
+      <el-form-item :label="$t('message.storage.warehouse')">
+        <el-select v-model="form.storage_uuid" filterable clearable>
+          <el-option v-for="item in storageOptions" :key="item.value" :label="item.label" :value="item.value" />
+        </el-select>
+      </el-form-item>
+      <el-form-item :label="$t('message.productManagement.productStock')">
+        <el-input-number v-model="form.number" :min="0" />
+      </el-form-item>
+      <el-form-item :label="$t('common.operation')">
+        <el-select v-model="form.operation">
+          <el-option value="increase" :label="$t('common.increase')" />
+          <el-option value="decrease" :label="$t('common.decrease')" />
+        </el-select>
+      </el-form-item>
+      <el-form-item :label="$t('message.storage.referenceNo')">
+        <el-input v-model="form.reference_number" />
+      </el-form-item>
+      <el-form-item>
+        <el-button type="primary" @click="submit">{{ $t('common.confirm') }}</el-button>
+      </el-form-item>
+    </el-form>
+  </div>
+</template>
+
+<script>
+import PageHead from '@/components/page-head.vue'
+import { getStorage } from '@/common/common-func'
+
+export default {
+  name: 'p-stock-adjust',
+  components: { PageHead },
+  data() {
+    return {
+      loading: false,
+      form: {
+        barcode: '',
+        location: '',
+        storage_uuid: '',
+        number: 0,
+        operation: 'increase',
+        reference_number: ''
+      },
+      storageOptions: []
+    }
+  },
+  computed: {
+    roleType() {
+      return this.$getRoleType(this.$route.path)
+    }
+  },
+  methods: {
+    async fetchStorage() {
+      const res = await getStorage('', this.roleType)
+      if (this.$isRequestSuccessful(res.code)) {
+        this.storageOptions = res.data.map(item => ({ label: item.name, value: item.storage_uuid }))
+      }
+    },
+    async submit() {
+      this.loading = true
+      const res = await this.$ajax({ url: '/api/product-stock/adjust-stock', method: 'post', data: this.form, roleType: this.roleType })
+      if (this.$isRequestSuccessful(res.code)) {
+        this.$message.success(this.$t('common.operationSuccessful'))
+      }
+      this.loading = false
+    }
+  },
+  mounted() {
+    this.fetchStorage()
+  }
+}
+</script>
+
+<style scoped>
+</style>
+

--- a/src/pages/stock-manage/p-stock-statistics.vue
+++ b/src/pages/stock-manage/p-stock-statistics.vue
@@ -1,0 +1,107 @@
+<template>
+  <div class="p-stock-statistics" v-loading="loading">
+    <PageHead :title="$t('navigate.inventoryStatistics')"></PageHead>
+    <SearchCard>
+      <el-form :inline="true" :model="queryForm" class="demo-form-inline">
+        <el-form-item>
+          <el-input v-model="queryForm.query" :placeholder="$t('common.pleaseInput')"></el-input>
+        </el-form-item>
+        <el-form-item>
+          <el-select v-model="queryForm.storage_uuid" filterable clearable :placeholder="$t('message.storage.warehouseSelect')">
+            <el-option v-for="item in storageOptions" :key="item.value" :label="item.label" :value="item.value" />
+          </el-select>
+        </el-form-item>
+        <el-form-item>
+          <el-date-picker v-model="queryForm.date" type="daterange" :range-separator="$t('common.to')"
+            :start-placeholder="$t('common.startTime')" :end-placeholder="$t('common.endTime')"
+            format="yyyy-MM-dd" value-format="timestamp" />
+        </el-form-item>
+        <el-form-item>
+          <el-button icon="el-icon-search" @click="fetchData">{{ $t('common.search') }}</el-button>
+        </el-form-item>
+      </el-form>
+    </SearchCard>
+    <el-tabs v-model="activeTab" @tab-click="handleTabChange">
+      <el-tab-pane name="total" :label="$t('message.inventory.totalStock')">
+        <el-table :data="tableData" style="width: 100%">
+          <el-table-column prop="barcode" label="Barcode" />
+          <el-table-column prop="sku" label="SKU" />
+          <el-table-column prop="name" :label="$t('common.name')" />
+          <el-table-column prop="number" :label="$t('message.productManagement.productStock')" />
+        </el-table>
+      </el-tab-pane>
+      <el-tab-pane name="location" :label="$t('message.inventory.locationStock')">
+        <el-table :data="tableData" style="width: 100%">
+          <el-table-column prop="location" :label="$t('message.storage.location')" />
+          <el-table-column prop="number" :label="$t('message.productManagement.productStock')" />
+        </el-table>
+      </el-tab-pane>
+      <el-tab-pane name="customer" :label="$t('message.inventory.customerStock')">
+        <el-table :data="tableData" style="width: 100%">
+          <el-table-column prop="owner" :label="$t('message.customerManagement.customer')" />
+          <el-table-column prop="number" :label="$t('message.productManagement.productStock')" />
+        </el-table>
+      </el-tab-pane>
+    </el-tabs>
+  </div>
+</template>
+
+<script>
+import PageHead from '@/components/page-head.vue'
+import SearchCard from '@/components/search-card.vue'
+import { getStorage } from '@/common/common-func'
+
+export default {
+  name: 'p-stock-statistics',
+  components: { PageHead, SearchCard },
+  data() {
+    return {
+      queryForm: { query: '', storage_uuid: '', date: [] },
+      storageOptions: [],
+      activeTab: 'total',
+      tableData: [],
+      loading: false
+    }
+  },
+  computed: {
+    roleType() {
+      return this.$getRoleType(this.$route.path)
+    }
+  },
+  methods: {
+    async fetchStorage() {
+      const res = await getStorage('', this.roleType)
+      if (this.$isRequestSuccessful(res.code)) {
+        this.storageOptions = res.data.map(item => ({ label: item.name, value: item.storage_uuid }))
+      }
+    },
+    async fetchData() {
+      this.loading = true
+      const params = {}
+      if (this.queryForm.query) params.query = this.queryForm.query
+      if (this.queryForm.storage_uuid) params.storage_uuid = this.queryForm.storage_uuid
+      if (Array.isArray(this.queryForm.date) && this.queryForm.date.length === 2) {
+        params.inbound_time_begin = this.queryForm.date[0]
+        params.inbound_time_end = this.queryForm.date[1]
+      }
+      let url = '/api/product-stock/query-total'
+      if (this.activeTab === 'location') url = '/api/product-stock/query-location'
+      if (this.activeTab === 'customer') url = '/api/product-stock/query-user'
+      const res = await this.$ajax({ url, method: 'get', params, roleType: this.roleType })
+      this.tableData = this.$isRequestSuccessful(res.code) ? res.data : []
+      this.loading = false
+    },
+    handleTabChange() {
+      this.fetchData()
+    }
+  },
+  async mounted() {
+    await this.fetchStorage()
+    this.fetchData()
+  }
+}
+</script>
+
+<style scoped>
+</style>
+


### PR DESCRIPTION
## Summary
- add new provider dashboard menu for inventory management
- implement Stock Statistics page with three tabs
- implement Stock Adjustment page to adjust stock
- localize new menu and page labels
- move inventory menu under warehousing services

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874fd284a90832cbc3e739aa8b0b5bd