### PR TITLE
Move inventory menu and update storage API

### DIFF
--- a/src/components/base-layout/navigate.js
+++ b/src/components/base-layout/navigate.js
@@ -108,30 +108,30 @@ export const navigationDataProvider = [
                 role: ['Provider', 'Operator'],
               },
             ]
-          }
-        ]
-      },
-      {
-        title: 'navigate.inventory',
-        name: 'p-inventory',
-        path: '/p-inventory',
-        icon: 'el-icon-s-data',
-        role: ['Provider', 'Operator'],
-        notRouter: true,
-        children: [
-          {
-            title: 'navigate.inventoryStatistics',
-            name: 'p-stock-statistics',
-            path: '/p/stock-statistics',
-            component: 'stock-manage/p-stock-statistics.vue',
-            role: ['Provider', 'Operator']
           },
           {
-            title: 'navigate.stockAdjustment',
-            name: 'p-stock-adjust',
-            path: '/p/stock-adjust',
-            component: 'stock-manage/p-stock-adjust.vue',
-            role: ['Provider', 'Operator']
+            title: 'navigate.inventory',
+            name: 'p-inventory',
+            path: '/p-inventory',
+            icon: 'el-icon-s-data',
+            role: ['Provider', 'Operator'],
+            notRouter: true,
+            children: [
+              {
+                title: 'navigate.inventoryStatistics',
+                name: 'p-stock-statistics',
+                path: '/p/stock-statistics',
+                component: 'stock-manage/p-stock-statistics.vue',
+                role: ['Provider', 'Operator']
+              },
+              {
+                title: 'navigate.stockAdjustment',
+                name: 'p-stock-adjust',
+                path: '/p/stock-adjust',
+                component: 'stock-manage/p-stock-adjust.vue',
+                role: ['Provider', 'Operator']
+              }
+            ]
           }
         ]
       },

--- a/src/pages/stock-manage/p-stock-adjust.vue
+++ b/src/pages/stock-manage/p-stock-adjust.vue
@@ -34,7 +34,7 @@
 
 <script>
 import PageHead from '@/components/page-head.vue'
-import { getStorage } from '@/common/common-func'
+import { getStorageDefinition } from '@/common/common-func'
 
 export default {
   name: 'p-stock-adjust',
@@ -60,9 +60,9 @@ export default {
   },
   methods: {
     async fetchStorage() {
-      const res = await getStorage('', this.roleType)
+      const res = await getStorageDefinition('', this.roleType)
       if (this.$isRequestSuccessful(res.code)) {
-        this.storageOptions = res.data.map(item => ({ label: item.name, value: item.storage_uuid }))
+        this.storageOptions = res.data.map(item => ({ label: item.name, value: item.storage_define_uuid }))
       }
     },
     async submit() {

--- a/src/pages/stock-manage/p-stock-statistics.vue
+++ b/src/pages/stock-manage/p-stock-statistics.vue
@@ -49,7 +49,7 @@
 <script>
 import PageHead from '@/components/page-head.vue'
 import SearchCard from '@/components/search-card.vue'
-import { getStorage } from '@/common/common-func'
+import { getStorageDefinition } from '@/common/common-func'
 
 export default {
   name: 'p-stock-statistics',
@@ -70,9 +70,9 @@ export default {
   },
   methods: {
     async fetchStorage() {
-      const res = await getStorage('', this.roleType)
+      const res = await getStorageDefinition('', this.roleType)
       if (this.$isRequestSuccessful(res.code)) {
-        this.storageOptions = res.data.map(item => ({ label: item.name, value: item.storage_uuid }))
+        this.storageOptions = res.data.map(item => ({ label: item.name, value: item.storage_define_uuid }))
       }
     },
     async fetchData() {


### PR DESCRIPTION
## Summary
- group provider inventory pages under warehousing services
- load storage definition via `getStorageDefinition` in stock pages

## Testing
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_687547f7b2b8832ca98c2ac88a6f3f37