### PR TITLE
Fix provider inventory nav and storage fetch

### DIFF
--- a/src/common/language.js
+++ b/src/common/language.js
@@ -4,17 +4,17 @@ import zhCnLang from 'element-ui/lib/locale/lang/zh-CN'
 import locale from 'element-ui/lib/locale'
 export function getLanguage () {
   // const localLanguage = getCookie('language_type') || 'en_us' zh_cn
-  let localLanguage = 'en_us'
+  let localLanguage = 'zh_cn'
   try {
     localLanguage = getCookie('language_type')
     if (!localLanguage) {
-      locale.use(enLang)
-      return 'en_us'
+      locale.use(zhCnLang)
+      return 'zh_cn'
     }
 
   } catch (e) {
-    locale.use(enLang)
-    return 'en_us'
+    locale.use(zhCnLang)
+    return 'zh_cn'
   }
   if (localLanguage === 'zh_cn') {
     locale.use(zhCnLang)

--- a/src/components/base-layout/navigate.js
+++ b/src/components/base-layout/navigate.js
@@ -109,29 +109,28 @@ export const navigationDataProvider = [
               },
             ]
           },
+        ]
+      },
+      {
+        title: 'navigate.inventory',
+        name: 'p-inventory',
+        path: '/p-inventory',
+        role: ['Provider', 'Operator'],
+        notRouter: true,
+        children: [
           {
-            title: 'navigate.inventory',
-            name: 'p-inventory',
-            path: '/p-inventory',
-            icon: 'el-icon-s-data',
-            role: ['Provider', 'Operator'],
-            notRouter: true,
-            children: [
-              {
-                title: 'navigate.inventoryStatistics',
-                name: 'p-stock-statistics',
-                path: '/p/stock-statistics',
-                component: 'stock-manage/p-stock-statistics.vue',
-                role: ['Provider', 'Operator']
-              },
-              {
-                title: 'navigate.stockAdjustment',
-                name: 'p-stock-adjust',
-                path: '/p/stock-adjust',
-                component: 'stock-manage/p-stock-adjust.vue',
-                role: ['Provider', 'Operator']
-              }
-            ]
+            title: 'navigate.inventoryStatistics',
+            name: 'p-stock-statistics',
+            path: '/p/stock-statistics',
+            component: 'stock-manage/p-stock-statistics.vue',
+            role: ['Provider', 'Operator']
+          },
+          {
+            title: 'navigate.stockAdjustment',
+            name: 'p-stock-adjust',
+            path: '/p/stock-adjust',
+            component: 'stock-manage/p-stock-adjust.vue',
+            role: ['Provider', 'Operator']
           }
         ]
       },

--- a/src/pages/stock-manage/p-stock-adjust.vue
+++ b/src/pages/stock-manage/p-stock-adjust.vue
@@ -56,11 +56,14 @@ export default {
   computed: {
     roleType() {
       return this.$getRoleType(this.$route.path)
+    },
+    provider_uuid () {
+      return this.$store.state.shopProviderUuid.shopInfo.provider_uuid
     }
   },
   methods: {
     async fetchStorage() {
-      const res = await getStorageDefinition('', this.roleType)
+      const res = await getStorageDefinition(this.provider_uuid, this.roleType)
       if (this.$isRequestSuccessful(res.code)) {
         this.storageOptions = res.data.map(item => ({ label: item.name, value: item.storage_define_uuid }))
       }

--- a/src/pages/stock-manage/p-stock-statistics.vue
+++ b/src/pages/stock-manage/p-stock-statistics.vue
@@ -66,11 +66,14 @@ export default {
   computed: {
     roleType() {
       return this.$getRoleType(this.$route.path)
+    },
+    provider_uuid () {
+      return this.$store.state.shopProviderUuid.shopInfo.provider_uuid
     }
   },
   methods: {
     async fetchStorage() {
-      const res = await getStorageDefinition('', this.roleType)
+      const res = await getStorageDefinition(this.provider_uuid, this.roleType)
       if (this.$isRequestSuccessful(res.code)) {
         this.storageOptions = res.data.map(item => ({ label: item.name, value: item.storage_define_uuid }))
       }


### PR DESCRIPTION
## Summary
- move provider inventory section outside of warehousing services and drop icon
- query storage definition with provider_uuid
- default language to Chinese when not specified

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6877ac1bb404832c88c51d122d44688a