### PR TITLE
Fix i18n locale from user preference on init

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -93,7 +93,8 @@ async function init() {
     i18n,
     created() {
       this.setTheme();
-      this.$i18n.locale = data.locale;
+      const userLanguage = this.$store.state.user.defaultLanguage || data.locale;
+      this.$i18n.locale = userLanguage;
       changeFavicon(data.homepage_icon);
       document.title = this.$i18n.locale === "en_us" ? data.homepage_title_en : data.homepage_title;
     },


### PR DESCRIPTION
## Summary
- ensure user preferred language is applied on startup

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a59581aac832c9dd54b078b1a3761