### PR TITLE
Restore direct quality inspection columns in product table

### DIFF
--- a/src/pages/product-manage/p-product.vue
+++ b/src/pages/product-manage/p-product.vue
@@ -450,6 +450,9 @@ export default {
     // 对数据进行格式化  一个变种一行以 变种为维度
     formatProductData(data) {
       const formattedData = []
+      if (!Array.isArray(data)) {
+        return formattedData
+      }
       data.forEach((item) => {
         const parentData = {
           product_uuid: item.product_uuid,
@@ -464,7 +467,13 @@ export default {
           source: item.source,
           shop: item.shop
         }
-        item.product_variants.forEach((variant, index) => {
+        const variants = Array.isArray(item.product_variants)
+          ? item.product_variants.filter((variantItem) => variantItem)
+          : []
+        variants.forEach((variant, index) => {
+          if (!variant) {
+            return
+          }
           if (index === 0) {
             variant.rowspan = item.rowspan
           } else {
@@ -474,9 +483,10 @@ export default {
             ...parentData,
             ...variant
           }
+          this.fillQualityInspectionFields(newVariant, variant)
           if (this.objectSpanFlag) {
             // 如果合并 每一条都是全部变种信息
-            newVariant.product_variants = item.product_variants
+            newVariant.product_variants = variants
           } else {
             //如果不合并 每个变种都只有单个变种信息
             newVariant.product_variants = [variant]
@@ -513,7 +523,7 @@ export default {
       })
         .then((res) => {
           if (this.$isRequestSuccessful(res.code)) {
-            this.tableData = utils.deepClone(res.data.result)
+            this.tableData = utils.deepClone(res.data.result || [])
             this.getRowCount()
             this.newTableData = this.formatProductData(
               utils.deepClone(this.tableData)
@@ -540,7 +550,10 @@ export default {
     // 标记需要合并的行
     getRowCount() {
       this.tableData.forEach((el, index) => {
-        el.rowspan = el.product_variants.length
+        const variants = Array.isArray(el.product_variants)
+          ? el.product_variants.filter((variantItem) => variantItem)
+          : []
+        el.rowspan = variants.length
       })
     },
     objectSpanMethod({ row, column, rowIndex, columnIndex }) {
@@ -672,6 +685,25 @@ export default {
     // 鼠标移出单元格时触发的方法
     cellMouseLeave(row, column, cell, event) {
       this.curRowArr = []
+    },
+    fillQualityInspectionFields(target, source) {
+      const fieldKeys = [
+        'quality_inspection_weight_kg',
+        'quality_inspection_length_cm',
+        'quality_inspection_width_cm',
+        'quality_inspection_height_cm'
+      ]
+      const qualityInfo = source && source.quality_inspection_info
+      if (!qualityInfo) {
+        return
+      }
+      fieldKeys.forEach((key) => {
+        if (target[key] === undefined || target[key] === null) {
+          if (qualityInfo[key] !== undefined && qualityInfo[key] !== null) {
+            target[key] = qualityInfo[key]
+          }
+        }
+      })
     }
   },
 


### PR DESCRIPTION
## Summary
- revert the product table quality inspection columns to read directly from the row payload
- keep formatting guards while only backfilling missing metrics from nested quality_inspection_info entries
- filter invalid variants when calculating row spans to avoid runtime issues

## Testing
- npm run lint *(fails: missing @vue/standard config in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68efd5322e24832c8f70dd85d2440dad