### PR TITLE
Comment out sourcing menu on user navigation

### DIFF
--- a/src/components/base-layout/navigate.js
+++ b/src/components/base-layout/navigate.js
@@ -284,14 +284,14 @@ export const navigationDataDs = [
     icon: 'el-icon-s-data',
     role: ['Drop shipper']
   },
-  {
-    title: 'navigate.sourcing',
-    name: 'ds-sourcing',
-    path: '/ds/sourcing',
-    icon: 'el-icon-search',
-    role: ['Drop shipper'],
-    component: 'sourcing/ds-sourcing.vue'
-  },
+  // {
+  //   title: 'navigate.sourcing',
+  //   name: 'ds-sourcing',
+  //   path: '/ds/sourcing',
+  //   icon: 'el-icon-search',
+  //   role: ['Drop shipper'],
+  //   component: 'sourcing/ds-sourcing.vue'
+  // },
   {
     title: 'navigate.myInventory',
     name: 'myinventory',


### PR DESCRIPTION
## Summary
- comment out the drop shipper sourcing navigation entry so it no longer renders in the user menu

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690b506678e4832c8c92019ecbce57e7